### PR TITLE
set memory growth flag to True to prevent memory errors

### DIFF
--- a/DeepMedicPlus/deepMedicRun
+++ b/DeepMedicPlus/deepMedicRun
@@ -27,6 +27,10 @@ from deepmedic.frontEnd.configParsing.modelParams import ModelParameters
 
 from tensorflow.python.client import device_lib
 
+import tensorflow as tf
+gpus = tf.config.experimental.list_physical_devices('GPU')
+for gpu in gpus:
+  tf.config.experimental.set_memory_growth(gpu, True)
 
 OPT_MODEL = "-model"
 OPT_TRAIN = "-train"


### PR DESCRIPTION
This piece of code should prevent some memory errors as I have experienced when running training. Note that it works only with tensorflow 2.2+